### PR TITLE
Renames .:? operator and adds optionalAndNull

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: redcard
-version: '0.2.1.0'
+version: '0.2.2.0'
 synopsis: Applicative Validation for JSON & XML
 category: Data
 author: Flipstone Technology Partners

--- a/redcard.cabal
+++ b/redcard.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 59d51013be12fd16187fad3cd75c7584e97f0400aec4a82c5dca4b53ee0ad27d
+-- hash: a4198563013da9258e152e4164c8ecf861636d4f5ad2a4dcd0d36044507ab216
 
 name:           redcard
-version:        0.2.1.0
+version:        0.2.2.0
 synopsis:       Applicative Validation for JSON & XML
 category:       Data
 author:         Flipstone Technology Partners

--- a/src/Data/Validation/Primitives.hs
+++ b/src/Data/Validation/Primitives.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Rank2Types #-}
 module Data.Validation.Primitives where
 
+import            Control.Monad (join)
 import            Data.Char
 import            Data.Convertible
 import            Data.Foldable
@@ -135,13 +136,16 @@ attrName -: validator = validateAttr attrName required
   where required (Just subvalue) = run validator subvalue
         required Nothing = Invalid (errMessage "must_be_present")
 
-(-:?) :: Text.Text -> Validator a -> Validator (Maybe a)
-attrName -:? validator = validateAttr attrName optional
-  where optional (Just value) = Just <$> run validator value
-        optional Nothing = Valid Nothing
+optional :: Text.Text -> Validator a -> Validator (Maybe a)
+attrName `optional` validator = validateAttr attrName opt
+  where opt (Just value) = Just <$> run validator value
+        opt Nothing = Valid Nothing
+
+optionalAndNullable :: Text.Text -> Validator a -> Validator (Maybe a)
+attrName `optionalAndNullable` validator = join <$> attrName `optional` (nullable validator)
 
 infixr 5 -:
-infixr 5 -:?
+infixr 5 `optional`
 
 notPresent :: Text.Text -> Validator ()
 notPresent attr = validateAttr attr $ isNotPresent

--- a/src/Data/Validation/Primitives.hs
+++ b/src/Data/Validation/Primitives.hs
@@ -131,7 +131,7 @@ nullable validator =
       either (const Nothing) Just
   <$> (mustBeNull `ifInvalid` validator)
 
-(-:) :: Text.Text -> Validator a -> Validator a
+required :: Text.Text -> Validator a -> Validator a
 attrName -: validator = validateAttr attrName required
   where required (Just subvalue) = run validator subvalue
         required Nothing = Invalid (errMessage "must_be_present")
@@ -144,14 +144,13 @@ attrName `optional` validator = validateAttr attrName opt
 optionalAndNullable :: Text.Text -> Validator a -> Validator (Maybe a)
 attrName `optionalAndNullable` validator = join <$> attrName `optional` (nullable validator)
 
-infixr 5 -:
+infixr 5 `required`
 infixr 5 `optional`
 
 notPresent :: Text.Text -> Validator ()
 notPresent attr = validateAttr attr $ isNotPresent
   where isNotPresent (Just _) = Invalid (errMessage "must_not_be_present")
         isNotPresent Nothing = Valid ()
-
 
 validateAttr :: Text.Text
              -> (forall input. Validatable input => Maybe input -> ValidationResult a)


### PR DESCRIPTION
The `.:?` has been renamed to `optional` so it is more
clear what the difference is between it and `nullable`.

Additionally, `optionalAndNull` has been added, which
should make it even more clear that `optional` and `nullable`
are doing different things.