### PR TITLE
GHC 8.8+ compatibility

### DIFF
--- a/src/Data/Validation/Types/Pure.hs
+++ b/src/Data/Validation/Types/Pure.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE Rank2Types #-}
 module Data.Validation.Types.Pure where
 
-#if MIN_VERSION_base(4,12,0)
+-- https://wiki.haskell.org/MonadFail_Proposal
+-- GHC 8.8 (base 4.13): "Fail is now a redundant module"
+#if MIN_VERSION_base(4,12,0) && !MIN_VERSION_base(4,13,0)
 import            Control.Monad.Fail (MonadFail(..))
 #endif
 import            Control.Applicative

--- a/src/Data/Validation/Types/Trans.hs
+++ b/src/Data/Validation/Types/Trans.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE Rank2Types #-}
 module Data.Validation.Types.Trans where
 
-#if MIN_VERSION_base(4,12,0)
+-- https://wiki.haskell.org/MonadFail_Proposal
+-- GHC 8.8 (base 4.13): "Fail is now a redundant module"
+#if MIN_VERSION_base(4,12,0) && !MIN_VERSION_base(4,13,0)
 import            Control.Monad.Fail (MonadFail(..))
 #endif
 import            Control.Monad.Trans.Class


### PR DESCRIPTION
This line causes a warning which is escalated into an error. I tested "cabal build" with GHC 9 with this patch, and it compiles without any issues. I also tested `stack --stack-yaml stack-lts-6.35.yml build` and that worked fine also (that is the oldest).