### PR TITLE
[ch21863] Add minimal test and Github Actions CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,72 @@
+# Haskell stack project Github Actions template
+# https://gist.github.com/mstksg/11f753d891cee5980326a8ea8c865233
+#
+# TODO:
+# * cache (https://github.com/actions/cache)
+#     but this is too small. native cacheing will come soon
+#     https://github.community/t5/GitHub-Actions/Caching-files-between-GitHub-Action-executions/m-p/30974/highlight/true#M630
+#     so we can wait for then.
+
+name: Redcard CI
+
+on:
+  push:
+  schedule:
+  - cron: "0 0 * * 1"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # use this to specify what resolvers and ghc to use
+        plan:
+        - { build: stack, resolver: "--stack-yaml stack-lts-13.28.yml"  }
+        - { build: stack, resolver: "--stack-yaml stack-lts-17.2.yml"  }
+        - { build: stack, resolver: "--stack-yaml stack-lts-17.2.yml --resolver nightly"  }
+        # use this to include any dependencies from OS package managers
+        include: []
+        # - os: ubuntu-latest
+        #   apt-get: happy libblas-dev liblapack-dev
+
+        #exclude:
+        #- os: macOS-latest
+        #  plan:
+        #    build: cabal
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install OS Packages
+      uses: mstksg/get-package@v1
+      with:
+        apt-get: ${{ matrix.apt-get }}
+    - uses: actions/checkout@v1
+
+    - name: Setup stack
+      uses: haskell/actions/setup@v1.2.3
+
+    - name: Install dependencies
+      run: |
+        set -ex
+        case "$BUILD" in
+          stack)
+            stack --no-terminal --install-ghc $ARGS test --only-dependencies
+            ;;
+        esac
+        set +ex
+      env:
+        ARGS: ${{ matrix.plan.resolver }}
+        BUILD: ${{ matrix.plan.build }}
+
+    - name: Build
+      run: |
+        set -ex
+        case "$BUILD" in
+          stack)
+            stack --no-terminal $ARGS test
+            ;;
+        esac
+        set +ex
+      env:
+        ARGS: ${{ matrix.plan.resolver }}
+        BUILD: ${{ matrix.plan.build }}

--- a/package.yaml
+++ b/package.yaml
@@ -36,3 +36,8 @@ library:
   - Data.Validation.Types.Pure
   - Data.Validation.Types.Trans
   - Data.Validation.XML
+tests:
+  redcard-test:
+    source-dirs: test
+    main: Main
+    dependencies: redcard

--- a/redcard.cabal
+++ b/redcard.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9db7a65e23df6bf5ec27a2c8456cf85e6735e5af5aa9cc070c963fce8c3506a6
+-- hash: 9d2e2449e14e66af6dc0e2f62b06767b17edef15902b1377892561e817ef26d5
 
 name:           redcard
 version:        0.2.4.0
@@ -40,6 +40,32 @@ library
     , containers
     , convertible
     , mtl
+    , scientific
+    , text
+    , transformers
+    , unordered-containers
+    , vector
+    , xml-conduit
+  default-language: Haskell2010
+
+test-suite redcard-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_redcard
+  hs-source-dirs:
+      test
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall -Werror -fno-warn-orphans -main-is Main
+  build-depends:
+      aeson
+    , aeson-pretty
+    , base >=4.8
+    , bytestring
+    , containers
+    , convertible
+    , mtl
+    , redcard
     , scientific
     , text
     , transformers

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+import Data.Validation
+import Data.Aeson
+
+rejectsAll :: ValidatorT IO Int
+rejectsAll = liftV $ Validator $ const $ Invalid (errMessage "I reject everything!")
+
+rejectsAllUsingFail :: ValidatorT IO Int
+rejectsAllUsingFail = liftV $ fail "Validator fail message which shouldn't be IO's fail"
+
+emptyJSON :: Value
+emptyJSON = toJSON ("" :: String)
+
+main :: IO ()
+main = do
+  -- Just verify that they do not throw
+  result1 <- runValidatorT rejectsAll emptyJSON
+  print result1
+  result2 <- runValidatorT rejectsAllUsingFail emptyJSON
+  print result2
+  pure ()


### PR DESCRIPTION
We build on the two listed Stackage LTSes, and in addition with the nightly resolver (which will run on GHC 9 currently).

The tests are currently failing because of [ch21859](https://app.clubhouse.io/flipstone/story/21859/redcard-conversion-failures-should-not-throw) .