### PR TITLE
[sc-22624] Upgrade Stack base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   dev:
-    image: flipstone/stack:v3-2.5.1
+    image: flipstone/stack:v4-2.7.1
     volumes:
       - .:/redcard
     working_dir: /redcard

--- a/redcard.cabal
+++ b/redcard.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2030140e25d0a3fc9d39fc16d020759dfbed5637e908343e94320b746f64271f
+-- hash: 9f384eb3dce43335dd571c102c71227e350708f635cb63d93d85b295cc4d9918
 
 name:           redcard
 version:        0.2.4.0
@@ -14,7 +14,8 @@ author:         Flipstone Technology Partners
 maintainer:     development@flipstone.com
 license:        AllRightsReserved
 license-file:   LICENSE
-tested-with:    GHC == 8.6.5, GHC == 9.0.1
+tested-with:
+    GHC == 8.6.5, GHC == 9.0.1
 build-type:     Simple
 
 library
@@ -30,7 +31,8 @@ library
       Paths_redcard
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings
+  default-extensions:
+      OverloadedStrings
   ghc-options: -Wall -Werror -Wcpp-undef -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -fno-warn-orphans
   build-depends:
       aeson
@@ -55,7 +57,8 @@ test-suite redcard-test
       Paths_redcard
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings
+  default-extensions:
+      OverloadedStrings
   ghc-options: -Wall -Werror -Wcpp-undef -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -fno-warn-orphans -main-is Main
   build-depends:
       aeson


### PR DESCRIPTION
This upgrades the project to use Stack 2.7.1.

Depending projects that also use the same Stack version will avoid
having the cabal file be regenerated.