### PR TITLE
Aeson 2 and GHC 9.2 compatibility

### DIFF
--- a/src/Data/Validation/Types/Pure.hs
+++ b/src/Data/Validation/Types/Pure.hs
@@ -80,7 +80,7 @@ instance Semigroup Errors where
 
 instance Monoid Errors where
   mempty = Messages Set.empty
-  mappend = errorsAppend
+  mappend = (<>)
 
 errorsAppend :: Errors
              -> Errors
@@ -95,7 +95,7 @@ instance Monoid a => Semigroup (ValidationResult a) where
 
 instance Monoid a => Monoid (ValidationResult a) where
   mempty = Valid mempty
-  mappend = validationResultAppend
+  mappend = (<>)
 
 validationResultAppend :: Monoid m
                        => ValidationResult m

--- a/src/Data/Validation/Types/Trans.hs
+++ b/src/Data/Validation/Types/Trans.hs
@@ -32,7 +32,7 @@ instance Applicative m => Applicative (ValidatorT m) where
     (fmap (<*>) (mf input)) <*> ma input
 
 instance Monad m => Monad (ValidatorT m) where
-  return a = ValidatorT (const (return (pure a)))
+  return = pure
   (ValidatorT ma) >>= f = ValidatorT $ \input -> do
     result <- ma input
     case result of

--- a/src/Data/Validation/XML.hs
+++ b/src/Data/Validation/XML.hs
@@ -124,7 +124,7 @@ instance Semigroup Content where
 
 instance Monoid Content where
   mempty = Content ""
-  mappend = contentAppend
+  mappend = (<>)
 
 contentAppend :: Content
               -> Content


### PR DESCRIPTION
GHC 9.2 added a new warning: '-Wnoncanonical-monoid-instances'.  Since
the warning is enabled by '-Wall', and we have '-Werror' on, compilation
fails. This commit resolves the issue by fixing the errors.

Aeson 2 refactors Object such that it isn't necessarily a HashMap.  To
adapt to these changes, we use CPP to conditionally enable code that
works with Aeson 2. Aeson 1 compatibility is retained.