### PR TITLE
[sc-32156] Exports VXML

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: redcard
-version: '0.4.0.0'
+version: '0.4.0.1'
 synopsis: Applicative Validation for JSON & XML
 category: Data
 author: Flipstone Technology Partners

--- a/redcard.cabal
+++ b/redcard.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           redcard
-version:        0.4.0.0
+version:        0.4.0.1
 synopsis:       Applicative Validation for JSON & XML
 category:       Data
 author:         Flipstone Technology Partners

--- a/src/Data/Validation/XML.hs
+++ b/src/Data/Validation/XML.hs
@@ -1,4 +1,7 @@
-module Data.Validation.XML (decodeValidXML)
+module Data.Validation.XML
+  ( decodeValidXML
+  , VXML (..)
+  )
 where
 
 import Control.Applicative


### PR DESCRIPTION
This exports `VXML` so we can use it for XML-only validators in other services.